### PR TITLE
Fix undefined optional request headers

### DIFF
--- a/src/templates/exportService.hbs
+++ b/src/templates/exportService.hbs
@@ -46,7 +46,9 @@ export const {{{name}}} = ({{>parameters}}): AxiosPromise<{{>result}}> => {
 
     {{#if parametersQuery}}
     {{#each parametersQuery}}
-    localVarQueryParameter['{{{prop}}}'] = {{{name}}};
+    if(typeof {{{name}}} !== 'undefined') {
+        localVarQueryParameter['{{{prop}}}'] = {{{name}}};
+    }
     {{/each}}
     {{/if}}
 


### PR DESCRIPTION
Optional headers were being added to requests with undefined parameters, causing weird results or even 400 errors for some enpdoints.