### PR TITLE
Preserve existing optional param functionality

### DIFF
--- a/src/templates/partials/isRequired.hbs
+++ b/src/templates/partials/isRequired.hbs
@@ -1,5 +1,5 @@
 {{~#if @root.useOptions~}}
-{{#unless isRequired}}?{{else if default}}?{{/unless}}
+{{#unless isRequired}}?{{/unless}}
 {{~else~}}
-{{#unless isRequired}}{{#unless default}}?{{/unless}}{{/unless}}
+{{#unless isRequired}}?{{/unless}}
 {{~/if~}}

--- a/src/templates/partials/parameters.hbs
+++ b/src/templates/partials/parameters.hbs
@@ -3,7 +3,7 @@
 {
 api,
 {{#each parameters}}
-{{{name}}}{{#if default}} = {{{default}}}{{/if}},
+{{{name}}}{{#if default}}{{#if isRequired}} = {{{default}}}{{/if}}{{/if}},
 {{/each}}
 options = {},
 }: {
@@ -20,8 +20,7 @@ options: any,
 
 api: BaseAPI,
 {{#each parameters}}
-{{{name}}}{{>isRequired}}: {{>type}}{{#if default}} = {{{default}}}{{/if}},
-{{/each}}
+{{{name}}}{{>isRequired}}: {{>type}}{{#if isRequired}} = {{{default}}}{{/if}}{{/if}},{{/each}}
 options: any = {},
 {{/if}}
 {{else}}


### PR DESCRIPTION
Params should prioritize being optional even if they have a default value provided in the documentation. This is currently causing issues with filter endpoints.