### PR TITLE
accept output paths for core/models/services/schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ $ openapi --help
     -i, --input <value>       OpenAPI specification, can be a path, url or string content (required)
     -o, --output <value>      Output directory (required)
     -c, --client <value>      HTTP client to generate [fetch, xhr, node] (default: "fetch")
+    --outputCore <value>      The relative location of the core output directory
+    --outputModels <value>    The relative location of the models output directory
+    --outputSchemas <value>   The relative location of the schemas output directory
+    --outputServices <value>  The relative location of the services output directory
     --useOptions              Use options instead of arguments
     --useUnionTypes           Use union types instead of enums
     --exportCore <value>      Write core files to disk (default: true)

--- a/bin/index.js
+++ b/bin/index.js
@@ -13,6 +13,10 @@ const params = program
     .requiredOption('-i, --input <value>', 'OpenAPI specification, can be a path, url or string content (required)')
     .requiredOption('-o, --output <value>', 'Output directory (required)')
     .option('-c, --client <value>', 'HTTP client to generate [fetch, xhr, node, axios]', 'fetch')
+    .option('--outputCore <value>', 'The relative location of the core output directory')
+    .option('--outputServices <value>', 'The relative location of the services output directory')
+    .option('--outputModels <value>', 'The relative location of the models output directory')
+    .option('--outputSchemas <value>', 'The relative location of the core output directory')
     .option('--useOptions', 'Use options instead of arguments')
     .option('--useUnionTypes', 'Use union types instead of enums')
     .option('--exportCore <value>', 'Write core files to disk', true)
@@ -29,6 +33,10 @@ if (OpenAPI) {
     OpenAPI.generate({
         input: params.input,
         output: params.output,
+        outputCore: params.outputCore,
+        outputServices: params.outputServices,
+        outputModels: params.outputModels,
+        outputSchemas: params.outputSchemas,
         httpClient: params.client,
         useOptions: params.useOptions,
         useUnionTypes: params.useUnionTypes,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { resolve } from 'path';
 import { HttpClient } from './HttpClient';
 import { parse as parseV2 } from './openApi/v2';
 import { parse as parseV3 } from './openApi/v3';
@@ -13,6 +14,10 @@ export { HttpClient } from './HttpClient';
 export type Options = {
     input: string | Record<string, any>;
     output: string;
+    outputCore?: string;
+    outputServices?: string;
+    outputModels?: string;
+    outputSchemas?: string;
     httpClient?: HttpClient;
     useOptions?: boolean;
     useUnionTypes?: boolean;
@@ -30,6 +35,10 @@ export type Options = {
  * service layer, etc.
  * @param input The relative location of the OpenAPI spec
  * @param output The relative location of the output directory
+ * @param outputCore The relative location of the core output directory
+ * @param outputModels The relative location of the models output directory
+ * @param outputSchemas The relative location of the schemas output directory
+ * @param outputServices The relative location of the services output directory
  * @param httpClient The selected httpClient (fetch or XHR)
  * @param useOptions Use options or arguments functions
  * @param useUnionTypes Use union types instead of enums
@@ -43,6 +52,10 @@ export type Options = {
 export async function generate({
     input,
     output,
+    outputCore = resolve(output, 'core'),
+    outputModels = resolve(output, 'models'),
+    outputServices = resolve(output, 'services'),
+    outputSchemas = resolve(output, 'schemas'),
     httpClient = HttpClient.FETCH,
     useOptions = false,
     useUnionTypes = false,
@@ -66,7 +79,23 @@ export async function generate({
             const client = parseV2(openApi);
             const clientFinal = postProcessClient(client);
             if (!write) break;
-            await writeClient(clientFinal, templates, output, httpClient, useOptions, useUnionTypes, exportCore, exportServices, exportModels, exportSchemas, request);
+            await writeClient(
+                clientFinal,
+                templates,
+                output,
+                outputCore,
+                outputModels,
+                outputSchemas,
+                outputServices,
+                httpClient,
+                useOptions,
+                useUnionTypes,
+                exportCore,
+                exportServices,
+                exportModels,
+                exportSchemas,
+                request
+            );
             break;
         }
 
@@ -74,7 +103,23 @@ export async function generate({
             const client = parseV3(openApi);
             const clientFinal = postProcessClient(client);
             if (!write) break;
-            await writeClient(clientFinal, templates, output, httpClient, useOptions, useUnionTypes, exportCore, exportServices, exportModels, exportSchemas, request);
+            await writeClient(
+                clientFinal,
+                templates,
+                output,
+                outputCore,
+                outputModels,
+                outputSchemas,
+                outputServices,
+                httpClient,
+                useOptions,
+                useUnionTypes,
+                exportCore,
+                exportServices,
+                exportModels,
+                exportSchemas,
+                request
+            );
             break;
         }
     }

--- a/src/templates/exportService.hbs
+++ b/src/templates/exportService.hbs
@@ -2,7 +2,7 @@
 
 {{#if imports}}
 {{#each imports}}
-import type { {{{this}}} } from '../models/{{{this}}}';
+import type { {{{this}}} } from '{{{@root.modelsPath}}}/{{{this}}}';
 {{/each}}
 {{/if}}
 import { BaseAPI, globalImportUrl, AxiosPromise } from '../core/request';

--- a/src/templates/index.hbs
+++ b/src/templates/index.hbs
@@ -1,22 +1,22 @@
 {{>header}}
 {{#if @root.exportCore}}
 
-export { ApiError } from './core/ApiError';
-export { OpenAPI } from './core/OpenAPI';
-export { BaseAPI } from './core/request';
+export { ApiError } from '{{{@root.corePath}}}/ApiError';
+export { OpenAPI } from '{{{@root.corePath}}}/OpenAPI';
+export { BaseAPI } from '{{{@root.corePath}}}/request';
 {{/if}}
 {{#if @root.exportModels}}
 {{#if models}}
 
 {{#each models}}
 {{#if @root.useUnionTypes}}
-export type { {{{name}}} } from './models/{{{name}}}';
+export type { {{{name}}} } from '{{{@root.modelsPath}}}/{{{name}}}';
 {{else if enum}}
-export { {{{name}}} } from './models/{{{name}}}';
+export { {{{name}}} } from '{{{@root.modelsPath}}}/{{{name}}}';
 {{else if enums}}
-export { {{{name}}} } from './models/{{{name}}}';
+export { {{{name}}} } from '{{{@root.modelsPath}}}/{{{name}}}';
 {{else}}
-export type { {{{name}}} } from './models/{{{name}}}';
+export type { {{{name}}} } from '{{{@root.modelsPath}}}/{{{name}}}';
 {{/if}}
 {{/each}}
 {{/if}}
@@ -25,7 +25,7 @@ export type { {{{name}}} } from './models/{{{name}}}';
 {{#if models}}
 
 {{#each models}}
-export { ${{{name}}} } from './schemas/${{{name}}}';
+export { ${{{name}}} } from '{{{@root.schemasPath}}}/${{{name}}}';
 {{/each}}
 {{/if}}
 {{/if}}
@@ -33,7 +33,7 @@ export { ${{{name}}} } from './schemas/${{{name}}}';
 {{#if services}}
 
 {{#each services}}
-export * from './services/{{{name}}}';
+export * from '{{{@root.servicesPath}}}/{{{name}}}';
 {{/each}}
 {{/if}}
 {{/if}}

--- a/src/utils/writeClient.ts
+++ b/src/utils/writeClient.ts
@@ -16,6 +16,10 @@ import { writeClientServices } from './writeClientServices';
  * @param client Client object with all the models, services, etc.
  * @param templates Templates wrapper with all loaded Handlebars templates
  * @param output The relative location of the output directory
+ * @param outputCore The relative location of the core output directory
+ * @param outputModels The relative location of the models output directory
+ * @param outputSchemas The relative location of the schemas output directory
+ * @param outputServices The relative location of the services output directory
  * @param httpClient The selected httpClient (fetch, xhr or node)
  * @param useOptions Use options or arguments functions
  * @param useUnionTypes Use union types instead of enums
@@ -29,6 +33,10 @@ export async function writeClient(
     client: Client,
     templates: Templates,
     output: string,
+    outputCore: string,
+    outputModels: string,
+    outputSchemas: string,
+    outputServices: string,
     httpClient: HttpClient,
     useOptions: boolean,
     useUnionTypes: boolean,
@@ -39,10 +47,10 @@ export async function writeClient(
     request?: string
 ): Promise<void> {
     const outputPath = resolve(process.cwd(), output);
-    const outputPathCore = resolve(outputPath, 'core');
-    const outputPathModels = resolve(outputPath, 'models');
-    const outputPathSchemas = resolve(outputPath, 'schemas');
-    const outputPathServices = resolve(outputPath, 'services');
+    const outputPathCore = resolve(process.cwd(), outputCore);
+    const outputPathModels = resolve(process.cwd(), outputModels);
+    const outputPathSchemas = resolve(process.cwd(), outputSchemas);
+    const outputPathServices = resolve(process.cwd(), outputServices);
 
     if (!isSubDirectory(process.cwd(), output)) {
         throw new Error(`Output folder is not a subdirectory of the current working directory`);
@@ -57,7 +65,7 @@ export async function writeClient(
     if (exportServices) {
         await rmdir(outputPathServices);
         await mkdir(outputPathServices);
-        await writeClientServices(client.services, templates, outputPathServices, httpClient, useUnionTypes, useOptions);
+        await writeClientServices(client.services, templates, outputPathServices, outputPathModels, httpClient, useUnionTypes, useOptions);
     }
 
     if (exportSchemas) {
@@ -74,6 +82,19 @@ export async function writeClient(
 
     if (exportCore || exportServices || exportSchemas || exportModels) {
         await mkdir(outputPath);
-        await writeClientIndex(client, templates, outputPath, useUnionTypes, exportCore, exportServices, exportModels, exportSchemas);
+        await writeClientIndex(
+            client,
+            templates,
+            outputPath,
+            outputPathCore,
+            outputPathModels,
+            outputPathSchemas,
+            outputPathServices,
+            useUnionTypes,
+            exportCore,
+            exportServices,
+            exportModels,
+            exportSchemas
+        );
     }
 }

--- a/src/utils/writeClientCore.spec.ts
+++ b/src/utils/writeClientCore.spec.ts
@@ -38,5 +38,6 @@ describe('writeClientCore', () => {
         expect(writeFile).toBeCalledWith('/ApiRequestOptions.ts', 'apiRequestOptions');
         expect(writeFile).toBeCalledWith('/ApiResult.ts', 'apiResult');
         expect(writeFile).toBeCalledWith('/request.ts', 'request');
+        expect(writeFile).toBeCalledWith('/index.ts', 'index');
     });
 });

--- a/src/utils/writeClientCore.ts
+++ b/src/utils/writeClientCore.ts
@@ -25,6 +25,17 @@ export async function writeClientCore(client: Client, templates: Templates, outp
     await writeFile(resolve(outputPath, 'ApiRequestOptions.ts'), templates.core.apiRequestOptions({}));
     await writeFile(resolve(outputPath, 'ApiResult.ts'), templates.core.apiResult({}));
     await writeFile(resolve(outputPath, 'request.ts'), templates.core.request(context));
+    const indexFile = resolve(outputPath, 'index.ts');
+    await writeFile(
+        indexFile,
+        templates.index({
+            exportCore: true,
+            exportServices: false,
+            exportModels: false,
+            exportSchemas: false,
+            corePath: '.',
+        })
+    );
 
     if (request) {
         const requestFile = resolve(process.cwd(), request);

--- a/src/utils/writeClientIndex.spec.ts
+++ b/src/utils/writeClientIndex.spec.ts
@@ -30,7 +30,7 @@ describe('writeClientIndex', () => {
             },
         };
 
-        await writeClientIndex(client, templates, '/', true, true, true, true, true);
+        await writeClientIndex(client, templates, '/', '/core', '/models', '/schemas', '/services', true, true, true, true, true);
 
         expect(writeFile).toBeCalledWith('/index.ts', 'index');
     });

--- a/src/utils/writeClientIndex.ts
+++ b/src/utils/writeClientIndex.ts
@@ -1,4 +1,4 @@
-import { resolve } from 'path';
+import { resolve, relative } from 'path';
 
 import type { Client } from '../client/interfaces/Client';
 import { writeFile } from './fileSystem';
@@ -23,6 +23,10 @@ export async function writeClientIndex(
     client: Client,
     templates: Templates,
     outputPath: string,
+    corePath: string,
+    modelsPath: string,
+    schemasPath: string,
+    servicesPath: string,
     useUnionTypes: boolean,
     exportCore: boolean,
     exportServices: boolean,
@@ -41,6 +45,10 @@ export async function writeClientIndex(
             version: client.version,
             models: sortModelsByName(client.models),
             services: sortServicesByName(client.services),
+            modelsPath: relative(outputPath, modelsPath),
+            schemasPath: relative(outputPath, schemasPath),
+            servicesPath: relative(outputPath, servicesPath),
+            corePath: relative(outputPath, corePath),
         })
     );
 }

--- a/src/utils/writeClientIndex.ts
+++ b/src/utils/writeClientIndex.ts
@@ -33,6 +33,11 @@ export async function writeClientIndex(
     exportModels: boolean,
     exportSchemas: boolean
 ): Promise<void> {
+    const modelsRelativePath = relative(outputPath, modelsPath);
+    const schemasRelativePath = relative(outputPath, schemasPath);
+    const servicesRelativePath = relative(outputPath, servicesPath);
+    const coreRelativePath = relative(outputPath, corePath);
+
     await writeFile(
         resolve(outputPath, 'index.ts'),
         templates.index({
@@ -45,10 +50,10 @@ export async function writeClientIndex(
             version: client.version,
             models: sortModelsByName(client.models),
             services: sortServicesByName(client.services),
-            modelsPath: relative(outputPath, modelsPath),
-            schemasPath: relative(outputPath, schemasPath),
-            servicesPath: relative(outputPath, servicesPath),
-            corePath: relative(outputPath, corePath),
+            modelsPath: modelsRelativePath.startsWith('../') ? modelsRelativePath : `./${modelsRelativePath}`,
+            schemasPath: schemasRelativePath.startsWith('../') ? schemasRelativePath : `./${schemasRelativePath}`,
+            servicesPath: servicesRelativePath.startsWith('../') ? servicesRelativePath : `./${servicesRelativePath}`,
+            corePath: coreRelativePath.startsWith('../') ? coreRelativePath : `./${coreRelativePath}`,
         })
     );
 }

--- a/src/utils/writeClientModels.spec.ts
+++ b/src/utils/writeClientModels.spec.ts
@@ -47,5 +47,6 @@ describe('writeClientModels', () => {
         await writeClientModels(models, templates, '/', HttpClient.FETCH, false);
 
         expect(writeFile).toBeCalledWith('/MyModel.ts', 'model');
+        expect(writeFile).toBeCalledWith('/index.ts', 'index');
     });
 });

--- a/src/utils/writeClientModels.ts
+++ b/src/utils/writeClientModels.ts
@@ -5,6 +5,7 @@ import { HttpClient } from '../HttpClient';
 import { writeFile } from './fileSystem';
 import { format } from './format';
 import { Templates } from './registerHandlebarTemplates';
+import { sortModelsByName } from './sortModelsByName';
 
 /**
  * Generate Models using the Handlebar template and write to disk.
@@ -24,4 +25,17 @@ export async function writeClientModels(models: Model[], templates: Templates, o
         });
         await writeFile(file, format(templateResult));
     }
+    const indexFile = resolve(outputPath, 'index.ts');
+    await writeFile(
+        indexFile,
+        templates.index({
+            exportCore: false,
+            exportServices: false,
+            exportModels: true,
+            exportSchemas: false,
+            useUnionTypes,
+            models: sortModelsByName(models),
+            modelsPath: '.',
+        })
+    );
 }

--- a/src/utils/writeClientServices.spec.ts
+++ b/src/utils/writeClientServices.spec.ts
@@ -32,8 +32,9 @@ describe('writeClientServices', () => {
             },
         };
 
-        await writeClientServices(services, templates, '/', HttpClient.FETCH, false, false);
+        await writeClientServices(services, templates, '/', '../models', HttpClient.FETCH, false, false);
 
         expect(writeFile).toBeCalledWith('/MyService.ts', 'service');
+        expect(writeFile).toBeCalledWith('/index.ts', 'index');
     });
 });

--- a/src/utils/writeClientServices.ts
+++ b/src/utils/writeClientServices.ts
@@ -17,12 +17,21 @@ const VERSION_TEMPLATE_STRING = 'OpenAPI.VERSION';
  * @param useUnionTypes Use union types instead of enums
  * @param useOptions Use options or arguments functions
  */
-export async function writeClientServices(services: Service[], templates: Templates, outputPath: string, httpClient: HttpClient, useUnionTypes: boolean, useOptions: boolean): Promise<void> {
+export async function writeClientServices(
+    services: Service[],
+    templates: Templates,
+    outputPath: string,
+    modelsOutputPath: string,
+    httpClient: HttpClient,
+    useUnionTypes: boolean,
+    useOptions: boolean
+): Promise<void> {
     for (const service of services) {
         const file = resolve(outputPath, `${service.name}.ts`);
         const useVersion = service.operations.some(operation => operation.path.includes(VERSION_TEMPLATE_STRING));
         const templateResult = templates.exports.service({
             ...service,
+            modelsPath: relative(outputPath, modelsOutputPath),
             httpClient,
             useUnionTypes,
             useVersion,

--- a/src/utils/writeClientServices.ts
+++ b/src/utils/writeClientServices.ts
@@ -1,10 +1,11 @@
-import { resolve } from 'path';
+import { resolve, relative } from 'path';
 
 import type { Service } from '../client/interfaces/Service';
 import { HttpClient } from '../HttpClient';
 import { writeFile } from './fileSystem';
 import { format } from './format';
 import { Templates } from './registerHandlebarTemplates';
+import { sortServicesByName } from './sortServicesByName';
 
 const VERSION_TEMPLATE_STRING = 'OpenAPI.VERSION';
 
@@ -39,4 +40,17 @@ export async function writeClientServices(
         });
         await writeFile(file, format(templateResult));
     }
+    const indexFile = resolve(outputPath, 'index.ts');
+    await writeFile(
+        indexFile,
+        templates.index({
+            exportCore: false,
+            exportServices: true,
+            exportModels: false,
+            exportSchemas: false,
+            useUnionTypes,
+            services: sortServicesByName(services),
+            servicesPath: '.',
+        })
+    );
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2,11 +2,16 @@ export declare enum HttpClient {
     FETCH = 'fetch',
     XHR = 'xhr',
     NODE = 'node',
+    AXIOS = 'axios',
 }
 
 export type Options = {
     input: string | Record<string, any>;
     output: string;
+    outputCore?: string;
+    outputServices?: string;
+    outputModels?: string;
+    outputSchemas?: string;
     httpClient?: HttpClient;
     useOptions?: boolean;
     useUnionTypes?: boolean;


### PR DESCRIPTION
Specify for core/models/services/schema to go to directories other than one output directory.  Add index for models/services/core.